### PR TITLE
feat: invoke rest timer when marking a set as complete

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -163,11 +163,11 @@ class _MyHomePageState extends State<MyHomePage> {
       ),
       body: _pages[_selectedIndex],
       bottomNavigationBar: BottomNavigationBar(
-        items: const [
-          BottomNavigationBarItem(icon: Icon(Icons.home), label: 'Home'),
-          BottomNavigationBarItem(
+        items: [
+          const BottomNavigationBarItem(icon: Icon(Icons.home), label: 'Home'),
+          const BottomNavigationBarItem(
               icon: Icon(Icons.fitness_center), label: 'Sets'),
-          BottomNavigationBarItem(
+          const BottomNavigationBarItem(
               icon: Icon(Icons.library_books), label: 'Exercises'),
           BottomNavigationBarItem(
               icon: Consumer<RestTimerViewModel>(
@@ -180,7 +180,7 @@ class _MyHomePageState extends State<MyHomePage> {
                 },
               ),
               label: 'Rest'),
-          BottomNavigationBarItem(
+          const BottomNavigationBarItem(
               icon: Icon(Icons.settings), label: 'Settings'),
         ],
         currentIndex: _selectedIndex,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -170,7 +170,16 @@ class _MyHomePageState extends State<MyHomePage> {
           BottomNavigationBarItem(
               icon: Icon(Icons.library_books), label: 'Exercises'),
           BottomNavigationBarItem(
-              icon: Icon(Icons.timer), label: 'Rest'),
+              icon: Consumer<RestTimerViewModel>(
+                builder: (context, viewModel, child) {
+                  return Badge(
+                    label: Text('${viewModel.remainingSeconds}'),
+                    isLabelVisible: viewModel.isRunning,
+                    child: const Icon(Icons.timer),
+                  );
+                },
+              ),
+              label: 'Rest'),
           BottomNavigationBarItem(
               icon: Icon(Icons.settings), label: 'Settings'),
         ],

--- a/lib/presentation/pages/exercise_sets_page.dart
+++ b/lib/presentation/pages/exercise_sets_page.dart
@@ -6,6 +6,7 @@ import 'package:exercise_management/data/models/exercise_set_presentation.dart';
 import 'package:exercise_management/data/models/exercise_set_presentation_mapper.dart';
 import 'package:exercise_management/presentation/pages/add_exercise_set_page.dart';
 import 'package:exercise_management/presentation/view_models/exercise_sets_view_model.dart';
+import 'package:exercise_management/presentation/view_models/rest_timer_view_model.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 
@@ -289,7 +290,7 @@ class ExerciseSetsPage extends StatelessWidget {
       subtitle: Text(_buildExerciseSubtitle(exercise)),
       onTap: () => _navigateToEditExerciseSet(context, exercise),
       onLongPress: () => exercise.setId != null
-          ? _toggleSetCompletion(exercise, viewModel)
+          ? _toggleSetCompletion(context, exercise, viewModel)
           : null,
       trailing: _buildActionButtons(exercise, viewModel),
     );
@@ -332,6 +333,7 @@ class ExerciseSetsPage extends StatelessWidget {
   }
 
   void _toggleSetCompletion(
+      BuildContext context,
       ExerciseSetPresentation exercise, ExerciseSetsViewModel viewModel) {
     final isCurrentlyCompleted = exercise.completedAt != null;
     final exerciseSet = exercise.toExerciseSet();
@@ -342,6 +344,10 @@ class ExerciseSetsPage extends StatelessWidget {
           isCurrentlyCompleted ? const Value(null) : Value(DateTime.now()),
     );
     viewModel.updateExerciseSet.execute(updatedSet);
+
+    if (!isCurrentlyCompleted) {
+      context.read<RestTimerViewModel>().startTimer();
+    }
   }
 
   void _progressSets(

--- a/lib/presentation/view_models/rest_timer_view_model.dart
+++ b/lib/presentation/view_models/rest_timer_view_model.dart
@@ -40,8 +40,7 @@ class RestTimerViewModel extends ChangeNotifier {
   }
 
   void startTimer() {
-    _timer?.cancel();
-    _notificationService.cancelNotification(_notificationId);
+    stopTimer();
 
     _isRunning = true;
     _endTime = clock.now().add(Duration(seconds: _selectedDuration));

--- a/lib/presentation/view_models/rest_timer_view_model.dart
+++ b/lib/presentation/view_models/rest_timer_view_model.dart
@@ -40,7 +40,8 @@ class RestTimerViewModel extends ChangeNotifier {
   }
 
   void startTimer() {
-    if (_isRunning) return;
+    _timer?.cancel();
+    _notificationService.cancelNotification(_notificationId);
 
     _isRunning = true;
     _endTime = clock.now().add(Duration(seconds: _selectedDuration));

--- a/lib/presentation/view_models/rest_timer_view_model.dart
+++ b/lib/presentation/view_models/rest_timer_view_model.dart
@@ -40,7 +40,9 @@ class RestTimerViewModel extends ChangeNotifier {
   }
 
   void startTimer() {
-    stopTimer();
+    if (_isRunning) {
+      stopTimer();
+    }
 
     _isRunning = true;
     _endTime = clock.now().add(Duration(seconds: _selectedDuration));

--- a/test/unit/presentation/pages/exercise_sets_page_test.dart
+++ b/test/unit/presentation/pages/exercise_sets_page_test.dart
@@ -12,6 +12,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:provider/provider.dart';
+import 'package:exercise_management/presentation/view_models/rest_timer_view_model.dart';
 
 class MockExerciseSetRepository extends Mock implements ExerciseSetRepository {}
 
@@ -21,12 +22,15 @@ class MockExerciseTemplateRepository extends Mock
 class MockExerciseSetPresentationRepository extends Mock
     implements ExerciseSetPresentationRepository {}
 
+class MockRestTimerViewModel extends Mock implements RestTimerViewModel {}
+
 void main() {
   group('ExerciseSetsPage Ranking', () {
     late MockExerciseSetRepository mockExerciseSetRepository;
     late MockExerciseTemplateRepository mockExerciseTemplateRepository;
     late MockExerciseSetPresentationRepository
         mockExerciseSetPresentationRepository;
+    late MockRestTimerViewModel mockRestTimerViewModel;
     late ExerciseSetsViewModel viewModel;
     late ExerciseRankingManager rankingManager;
 
@@ -51,6 +55,8 @@ void main() {
       mockExerciseTemplateRepository = MockExerciseTemplateRepository();
       mockExerciseSetPresentationRepository =
           MockExerciseSetPresentationRepository();
+      mockRestTimerViewModel = MockRestTimerViewModel();
+      when(() => mockRestTimerViewModel.startTimer()).thenAnswer((_) {});
       rankingManager = ExerciseRankingManager();
 
       viewModel = ExerciseSetsViewModel(
@@ -150,6 +156,9 @@ void main() {
             Provider<ExerciseRankingManager>.value(
               value: rankingManager,
             ),
+            ChangeNotifierProvider<RestTimerViewModel>.value(
+              value: mockRestTimerViewModel,
+            ),
           ],
           child: const MaterialApp(
             home: Scaffold(
@@ -214,6 +223,9 @@ void main() {
             ),
             Provider<ExerciseRankingManager>.value(
               value: rankingManager,
+            ),
+            ChangeNotifierProvider<RestTimerViewModel>.value(
+              value: mockRestTimerViewModel,
             ),
           ],
           child: const MaterialApp(
@@ -288,6 +300,7 @@ void main() {
     late MockExerciseTemplateRepository mockExerciseTemplateRepository;
     late MockExerciseSetPresentationRepository
         mockExerciseSetPresentationRepository;
+    late MockRestTimerViewModel mockRestTimerViewModel;
     late ExerciseSetsViewModel viewModel;
     late ExerciseRankingManager rankingManager;
 
@@ -310,6 +323,8 @@ void main() {
       mockExerciseTemplateRepository = MockExerciseTemplateRepository();
       mockExerciseSetPresentationRepository =
           MockExerciseSetPresentationRepository();
+      mockRestTimerViewModel = MockRestTimerViewModel();
+      when(() => mockRestTimerViewModel.startTimer()).thenAnswer((_) {});
       rankingManager = ExerciseRankingManager();
 
       viewModel = ExerciseSetsViewModel(
@@ -389,6 +404,9 @@ void main() {
             Provider<ExerciseRankingManager>.value(
               value: rankingManager,
             ),
+            ChangeNotifierProvider<RestTimerViewModel>.value(
+              value: mockRestTimerViewModel,
+            ),
           ],
           child: const MaterialApp(
             home: Scaffold(
@@ -426,6 +444,7 @@ void main() {
     late MockExerciseTemplateRepository mockExerciseTemplateRepository;
     late MockExerciseSetPresentationRepository
         mockExerciseSetPresentationRepository;
+    late MockRestTimerViewModel mockRestTimerViewModel;
     late ExerciseSetsViewModel viewModel;
     late ExerciseRankingManager rankingManager;
 
@@ -448,6 +467,8 @@ void main() {
       mockExerciseTemplateRepository = MockExerciseTemplateRepository();
       mockExerciseSetPresentationRepository =
           MockExerciseSetPresentationRepository();
+      mockRestTimerViewModel = MockRestTimerViewModel();
+      when(() => mockRestTimerViewModel.startTimer()).thenAnswer((_) {});
       rankingManager = ExerciseRankingManager();
 
       viewModel = ExerciseSetsViewModel(
@@ -504,6 +525,9 @@ void main() {
             ),
             Provider<ExerciseRankingManager>.value(
               value: rankingManager,
+            ),
+            ChangeNotifierProvider<RestTimerViewModel>.value(
+              value: mockRestTimerViewModel,
             ),
           ],
           child: const MaterialApp(
@@ -576,6 +600,9 @@ void main() {
             ),
             Provider<ExerciseRankingManager>.value(
               value: rankingManager,
+            ),
+            ChangeNotifierProvider<RestTimerViewModel>.value(
+              value: mockRestTimerViewModel,
             ),
           ],
           child: const MaterialApp(


### PR DESCRIPTION
This PR implements the automatic invocation of the rest timer when an exercise set is marked as complete.

### Changes:
- **Automatic Rest Timer:** When a set is toggled to completed, the RestTimerViewModel.startTimer() is invoked.
- **Timer Restart Logic:** The startTimer() method now resets and restarts the timer if it was already running, ensuring a fresh rest period for every set.
- **Live Countdown Badge:** Added a dynamic badge to the Rest tab icon in the bottom navigation bar that shows the remaining seconds when the timer is active.
- **Improved Performance:** Optimized the navigation bar to use scoped rebuilds via Consumer and preserved const optimizations for static tabs.
- **Testing:** Updated unit and widget tests to accommodate the new behavior and ensure 100% test pass rate.